### PR TITLE
[CI] autoupdate hooks (+ minor fix-up to README)

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -32,7 +32,7 @@ repos:
       - id: mixed-line-ending
 
   - repo: https://github.com/RobertCraigie/pyright-python
-    rev: v1.1.398
+    rev: v1.1.400
     hooks:
       - id: pyright
         additional_dependencies:
@@ -60,7 +60,7 @@ repos:
           ]
 
   - repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: v0.11.4
+    rev: v0.11.8
     hooks:
       - id: ruff
         args: [

--- a/README.md
+++ b/README.md
@@ -90,7 +90,7 @@ The scripts support the following inference providers:
 
 #### NVIDIA External (w/ rate limits)
 
-- **Default LLM Model:** `meta/llama-3.1-70b-instruct`
+- **Default LLM Model:** `meta/llama-3.3-70b-instruct`
 - **Default Embedding Model:** `NV-Embed-QA`
 - **Default Vision Model:** `meta/llama-3.2-90b-vision-instruct`
 - **Environment Variable:** `NVIDIA_API_KEY` (required - get [HERE](https://build.nvidia.com/))


### PR DESCRIPTION
1. Ran the `pre-commit autoupdate` to get the latest hooks' versions
2. Fixed a minor mistake in the `README.md`
