### PR TITLE
Update dependencies, model list, and legacy LangChain imports

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,6 +1,6 @@
 repos:
   - repo: https://github.com/PyCQA/autoflake
-    rev: v2.3.1
+    rev: v2.3.3
     hooks:
       - id: autoflake
         args: [
@@ -9,7 +9,7 @@ repos:
         ]
 
   - repo: https://github.com/asottile/pyupgrade
-    rev: v3.19.1 # Last version that supports Python 3.8.*
+    rev: v3.21.2
     hooks:
       - id: pyupgrade
         # Version matches minimal supported python version (see setup.py)
@@ -19,7 +19,7 @@ repos:
         ]
 
   - repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v5.0.0
+    rev: v6.0.0
     hooks:
       - id: trailing-whitespace
       - id: check-added-large-files
@@ -32,7 +32,7 @@ repos:
       - id: mixed-line-ending
 
   - repo: https://github.com/RobertCraigie/pyright-python
-    rev: v1.1.400
+    rev: v1.1.408
     hooks:
       - id: pyright
         additional_dependencies:
@@ -42,6 +42,7 @@ repos:
             'httpx',
             'langchain',
             'langchain-anthropic',
+            'langchain-classic',
             'langchain-community',
             'langchain-core',
             'langchain-nvidia-ai-endpoints',
@@ -60,9 +61,9 @@ repos:
           ]
 
   - repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: v0.11.8
+    rev: v0.15.4
     hooks:
-      - id: ruff
+      - id: ruff-check
         args: [
           --fix,
           --ignore,

--- a/04_example_chat_memory_and_grades.py
+++ b/04_example_chat_memory_and_grades.py
@@ -138,8 +138,8 @@ else:
 # Component #4 - LLM Response Generation and Chat
 ############################################
 
-from langchain.chains import ConversationChain
-from langchain.chains.conversation.memory import ConversationBufferMemory
+from langchain_classic.chains import ConversationChain
+from langchain_classic.memory import ConversationBufferMemory
 
 st.subheader("Chat with your AI Assistant, Envie!")
 

--- a/05_example_rag_agent_graph.py
+++ b/05_example_rag_agent_graph.py
@@ -394,7 +394,7 @@ def web_search_node(state: RagStateTotal) -> RagState:
     """
     Web search based on the question
     Expected state.question and state.remaining_documents
-    Updates state.remaining_documents
+    Updates state.remaining_documents and state.do_web_search
     """
     print("---WEB SEARCH---")
     # TODO: Remove remaining_documents?
@@ -407,7 +407,10 @@ def web_search_node(state: RagStateTotal) -> RagState:
     )
     web_results = Document(page_content=web_search_results_flattened_content)
 
-    return {"remaining_documents": documents + [web_results]}
+    return {
+        "remaining_documents": documents + [web_results],
+        "do_web_search": True,  # Mark that we performed a web search (for final state)
+    }
 
 
 ###################################################################################

--- a/06_example_structured_vision_understanding.py
+++ b/06_example_structured_vision_understanding.py
@@ -5,8 +5,8 @@ import json
 from pathlib import Path
 from typing import Any, Literal, TypedDict
 
-from langchain import globals as lc_globals
-from langchain.chains import TransformChain
+from langchain_core.globals import set_debug
+from langchain_classic.chains import TransformChain
 from langchain_core.messages import HumanMessage
 from langchain_core.output_parsers import JsonOutputParser
 from langchain_core.runnables import chain
@@ -184,7 +184,7 @@ if __name__ == "__main__":
 
     args = parse_args()
     if args.debug:
-        lc_globals.set_debug(True)
+        set_debug(True)
     PROVIDER_CLASS = ProviderFactory.get_provider(args.inference_provider)
     PROVIDER_CLASS.initialize_provider()
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,6 +2,7 @@ faiss-cpu
 httpx
 langchain
 langchain-anthropic
+langchain-classic
 langchain-community
 langchain-core
 langchain-nvidia-ai-endpoints


### PR DESCRIPTION
## Summary

This MR brings the codebase up to date across three areas: LangChain import paths, and pre-commit tooling versions.

##  @Changes

### 1. Migrate legacy LangChain imports to `langchain-classic`

Replaced deprecated `langchain` imports in example scripts with their `langchain-classic` / `langchain-core` equivalents:

| File | Change |
|------|--------|
| `04_example_chat_memory_and_grades.py` | `langchain.chains` / `langchain.chains.conversation.memory` -> `langchain_classic.chains` / `langchain_classic.memory` |
| `06_example_structured_vision_understanding.py` | `langchain.globals` -> `langchain_core.globals`; `langchain.chains.TransformChain` -> `langchain_classic.chains.TransformChain` |
| `requirements.txt` | Added `langchain-classic` dependency |

### 2. Track web search execution in RAG agent graph (`05_example_rag_agent_graph.py`)

- The `web_search_node` now sets a `do_web_search: True` flag in the returned state, making it possible to tell from the final graph state whether a web search was performed.

### 3. Bump pre-commit hook versions (`.pre-commit-config.yaml`)

| Hook | Old | New |
|------|-----|-----|
| autoflake | v2.3.1 | v2.3.3 |
| pyupgrade | v3.19.1 | v3.21.2 |
| pre-commit-hooks | v5.0.0 | v6.0.0 |
| pyright | v1.1.400 | v1.1.408 |
| ruff | v0.11.8 (`ruff`) | v0.15.4 (`ruff-check`) |

Also added `langchain-classic` to pyright's `additional_dependencies` so type checking resolves the new import paths.
